### PR TITLE
Pin lambda module version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@
   */
 
 module "lambda" {
-  source = "claranet/lambda/aws"
+  source = "github.com/claranet/terraform-aws-lambda?ref=v0.11.2"
 
   function_name = "${var.name}"
   description   = "Attaches Elastic IPs to instances"


### PR DESCRIPTION
I used the github.com source format as opposed to using the version argument because it is compatible with older versions of Terraform.

Resolves #1 