### PR TITLE
Fix error logging

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -50,17 +50,17 @@ def lambda_handler(event, context):
                                 ec2.modify_instance_attribute(
                                         SourceDestCheck={'Value': False},
                                         InstanceId=resource_id)
-                        except:
-                            print("Error associating %s with %s" %
-                                  public_ip, resource_id)
+                        except Exception as error:
+                            print("Error associating %s with %s - %s" %
+                                  (public_ip, resource_id, error))
                     if resource_type == 'network-interface':
                         try:
                             assoc_response = ec2.associate_address(
                                     AllocationId=allocation_id,
                                     NetworkInterfaceId=resource_id)
-                        except:
-                            print("Error associating %s with %s" %
-                                  (public_ip, resource_id))
+                        except Exception as error:
+                            print("Error associating %s with %s - %s" %
+                                  (public_ip, resource_id, error))
                     assocation_id = assoc_response.get('AssociationId')
                     if assocation_id:
                         print ("%s given to %s (%s)" % (public_ip,


### PR DESCRIPTION
The first of these print statements caused the function to fail because of some missing brackets. I have fixed that and also added the error message to the output.

Resolves #3 