### PR TITLE
Bump lambda module version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@
   */
 
 module "lambda" {
-  source = "github.com/claranet/terraform-aws-lambda?ref=v0.11.2"
+  source = "github.com/claranet/terraform-aws-lambda?ref=v0.12.0"
 
   function_name = "${var.name}"
   description   = "Attaches Elastic IPs to instances"


### PR DESCRIPTION
Default concurrency is otherwise set to 0, which disables the lambda
function.